### PR TITLE
Update to modern Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,8 @@ documentation = "https://docs.rs/test-assets/"
 repository = "https://github.com/est31/test-assets"
 readme = "README.md"
 authors = ["est31 <MTest31@outlook.com>"]
+edition = "2021"
 
 [dependencies]
 curl = "0.4"
-sha2 = "0.1"
+sha2 = "0.10.6"

--- a/src/hash_list.rs
+++ b/src/hash_list.rs
@@ -8,66 +8,72 @@
 Hash list module
 */
 
-use std::io::{Write, BufRead, BufReader, BufWriter};
-use ::Sha256Hash;
+use crate::Sha256Hash;
+use crate::TaError;
 use std::collections::HashMap;
-use ::TaError;
+use std::{
+    fs::File,
+    io::{BufRead, BufReader, BufWriter, Write},
+};
 
 pub struct HashList {
-	name_to_hash_map :HashMap<String, Sha256Hash>,
+    name_to_hash_map: HashMap<String, Sha256Hash>,
 }
 
 impl HashList {
-	pub fn from_file(path :&str) -> Result<Self, TaError> {
-		use std::fs::File;
-		let rdr = try!(File::open(path));
-		let mut brdr = BufReader::new(rdr);
-		return Ok(try!(HashList::from_reader(&mut brdr)));
-	}
+    pub fn from_file(path: &str) -> Result<Self, TaError> {
+        let rdr = File::open(path)?;
+        let mut brdr = BufReader::new(rdr);
+        return Ok(HashList::from_reader(&mut brdr)?);
+    }
 
-	pub fn from_reader<T :BufRead>(brdr :&mut T) -> Result<Self, TaError> {
-		let mut name_to_hash_map = HashMap::new();
-		for oline in brdr.lines() {
-			let line = try!(oline);
-			if line.starts_with("#") {
-				continue;
-			}
-			let mut spi = line.split(" ");
-			let hash_str = match spi.next() { Some(v) => v, None => continue };
-			let hash = try!(Sha256Hash::from_hex(hash_str).map_err(|_| TaError::BadHashFormat));
-			let name = match spi.next() { Some(v) => v, None => continue };
-			name_to_hash_map.insert(name.to_owned(), hash);
-		}
-		return Ok(HashList {
-			name_to_hash_map : name_to_hash_map,
-		});
-	}
+    pub fn from_reader<T: BufRead>(brdr: &mut T) -> Result<Self, TaError> {
+        let mut name_to_hash_map = HashMap::new();
+        for oline in brdr.lines() {
+            let line = oline?;
+            if line.starts_with("#") {
+                continue;
+            }
+            let mut spi = line.split(" ");
+            let hash_str = match spi.next() {
+                Some(v) => v,
+                None => continue,
+            };
+            let hash = Sha256Hash::from_hex(hash_str).map_err(|_| TaError::BadHashFormat)?;
+            let name = match spi.next() {
+                Some(v) => v,
+                None => continue,
+            };
+            name_to_hash_map.insert(name.to_owned(), hash);
+        }
+        return Ok(HashList { name_to_hash_map });
+    }
 
-	pub fn to_file(&self, path :&str) -> Result<(), TaError> {
-		use std::fs::File;
-		let wrt = try!(File::create(path));
-		let mut bwrtr = BufWriter::new(wrt);
-		self.to_writer(&mut bwrtr)
-	}
+    pub fn to_file(&self, path: &str) -> Result<(), TaError> {
+        let wrt = File::create(path)?;
+        let mut bwrtr = BufWriter::new(wrt);
+        self.to_writer(&mut bwrtr)
+    }
 
-	pub fn to_writer<W :Write>(&self, bwrtr :&mut BufWriter<W>) -> Result<(), TaError> {
-		for (name, hash) in &self.name_to_hash_map {
-			try!(bwrtr.write(format!("{} {}\n", hash.to_hex(), name).as_bytes()));
-		}
-		Ok(())
-	}
+    pub fn to_writer<W: Write>(&self, bwrtr: &mut BufWriter<W>) -> Result<(), TaError> {
+        for (name, hash) in &self.name_to_hash_map {
+            bwrtr.write(format!("{} {}\n", hash.to_hex(), name).as_bytes())?;
+        }
+        Ok(())
+    }
 
-	pub fn new() -> Self {
-		return HashList {
-			name_to_hash_map : HashMap::new(),
-		};
-	}
+    pub fn new() -> Self {
+        return HashList {
+            name_to_hash_map: HashMap::new(),
+        };
+    }
 
-	pub fn get_hash<'a>(&'a self, filename :&str) -> Option<&'a Sha256Hash> {
-		self.name_to_hash_map.get(filename)
-	}
+    pub fn get_hash<'a>(&'a self, filename: &str) -> Option<&'a Sha256Hash> {
+        self.name_to_hash_map.get(filename)
+    }
 
-	pub fn add_entry(&mut self, filename :&str, hash :&Sha256Hash) {
-		self.name_to_hash_map.insert(filename.to_owned(), hash.clone());
-	}
+    pub fn add_entry(&mut self, filename: &str, hash: &Sha256Hash) {
+        self.name_to_hash_map
+            .insert(filename.to_owned(), hash.clone());
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,22 +21,22 @@ Usage example:
 ```
 #[test]
 fn some_awesome_test() {
-	let asset_defs = [
-		TestAssetDef {
-			filename : format!("file_a.png"),
-			hash : format!("<sha256 here>"),
-			url : format!("https://url/to/a.png"),
-		},
-		TestAssetDef {
-			filename : format!("file_b.png"),
-			hash : format!("<sha256 here>"),
-			url : format!("https://url/to/a.png"),
-		},
-	];
-	test_assets::download_test_files(&asset_defs,
-		"test-assets", true).unwrap();
-	// use your files here
-	// with path under test-assets/file_a.png and test-assets/file_b.png
+    let asset_defs = [
+        TestAssetDef {
+            filename : format!("file_a.png"),
+            hash : format!("<sha256 here>"),
+            url : format!("https://url/to/a.png"),
+        },
+        TestAssetDef {
+            filename : format!("file_b.png"),
+            hash : format!("<sha256 here>"),
+            url : format!("https://url/to/a.png"),
+        },
+    ];
+    test_assets::download_test_files(&asset_defs,
+        "test-assets", true).unwrap();
+    // use your files here
+    // with path under test-assets/file_a.png and test-assets/file_b.png
 }
 ```
 
@@ -44,29 +44,28 @@ If you have run the test once, it will re-use the files
 instead of re-downloading them.
 */
 
-extern crate sha2;
 extern crate curl;
+extern crate sha2;
 
 mod hash_list;
 
-use std::io;
 use curl::easy::Easy;
-use sha2::sha2::Sha256;
-use sha2::digest::Digest;
 use hash_list::HashList;
-use std::fs::create_dir_all;
-
+use sha2::digest::Digest;
+use sha2::Sha256;
+use std::fs::{create_dir_all, File};
+use std::io::{self, Write};
 
 /// Definition for a test file
 ///
 ///
 pub struct TestAssetDef {
-	/// Name of the file on disk. This should be unique for the file.
-	pub filename :String,
-	/// Sha256 hash of the file's data in hexadecimal lowercase representation
-	pub hash :String,
-	/// The url the test file can be obtained from
-	pub url :String,
+    /// Name of the file on disk. This should be unique for the file.
+    pub filename: String,
+    /// Sha256 hash of the file's data in hexadecimal lowercase representation
+    pub hash: String,
+    /// The url the test file can be obtained from
+    pub url: String,
 }
 
 /// A type for a Sha256 hash value
@@ -76,149 +75,162 @@ pub struct TestAssetDef {
 pub struct Sha256Hash([u8; 32]);
 
 impl Sha256Hash {
+    pub fn from_digest(sha: Sha256) -> Self {
+        let sha = sha.finalize();
+        let bytes = sha[..].try_into().unwrap();
+        Sha256Hash(bytes)
+    }
 
-	pub fn from_digest(sha :&mut Sha256) -> Self {
-		let mut res = Sha256Hash([0; 32]);
-		sha.result(&mut res.0);
-		return res;
-	}
-
-	/// Converts the hexadecimal string to a hash value
-	pub fn from_hex(s :&str) -> Result<Self, ()> {
-		let mut res = Sha256Hash([0; 32]);
-		let mut idx = 0;
-		let mut iter = s.chars();
-		loop {
-			let upper = match iter.next().and_then(|c| c.to_digit(16)) {
-				Some(v) => v as u8,
-				None => try!(Err(())),
-			};
-			let lower = match iter.next().and_then(|c| c.to_digit(16)) {
-				Some(v) => v as u8,
-				None => try!(Err(())),
-			};
-			res.0[idx] = (upper << 4) | lower;
-			idx += 1;
-			if idx == 32 {
-				break;
-			}
-		}
-		return Ok(res);
-	}
-	/// Converts the hash value to hexadecimal
-	pub fn to_hex(&self) -> String {
-		let mut res = String::with_capacity(64);
-		for v in self.0.iter() {
-			use std::char::from_digit;
-			res.push(from_digit(*v as u32 >> 4, 16).unwrap());
-			res.push(from_digit(*v as u32 & 15, 16).unwrap());
-		}
-		return res;
-	}
+    /// Converts the hexadecimal string to a hash value
+    pub fn from_hex(s: &str) -> Result<Self, ()> {
+        let mut res = Sha256Hash([0; 32]);
+        let mut idx = 0;
+        let mut iter = s.chars();
+        loop {
+            let upper = match iter.next().and_then(|c| c.to_digit(16)) {
+                Some(v) => v as u8,
+                None => return Err(()),
+            };
+            let lower = match iter.next().and_then(|c| c.to_digit(16)) {
+                Some(v) => v as u8,
+                None => return Err(()),
+            };
+            res.0[idx] = (upper << 4) | lower;
+            idx += 1;
+            if idx == 32 {
+                break;
+            }
+        }
+        return Ok(res);
+    }
+    /// Converts the hash value to hexadecimal
+    pub fn to_hex(&self) -> String {
+        let mut res = String::with_capacity(64);
+        for v in self.0.iter() {
+            use std::char::from_digit;
+            res.push(from_digit(*v as u32 >> 4, 16).unwrap());
+            res.push(from_digit(*v as u32 & 15, 16).unwrap());
+        }
+        return res;
+    }
 }
 
 #[derive(Debug)]
 pub enum TaError {
-	Io(io::Error),
-	Curl(curl::Error),
-	DownloadFailed(u32),
-	BadHashFormat,
+    Io(io::Error),
+    Curl(curl::Error),
+    DownloadFailed(u32),
+    BadHashFormat,
 }
 
 impl From<io::Error> for TaError {
-	fn from(err :io::Error) -> TaError {
-		TaError::Io(err)
-	}
+    fn from(err: io::Error) -> TaError {
+        TaError::Io(err)
+    }
 }
 
 impl From<curl::Error> for TaError {
-	fn from(err :curl::Error) -> TaError {
-		TaError::Curl(err)
-	}
+    fn from(err: curl::Error) -> TaError {
+        TaError::Curl(err)
+    }
 }
 
 enum DownloadOutcome {
-	WithHash(Sha256Hash),
-	DownloadFailed(u32),
+    WithHash(Sha256Hash),
+    DownloadFailed(u32),
 }
 
-fn download_test_file(client :&mut Easy,
-		tfile :&TestAssetDef, dir :&str) -> Result<DownloadOutcome, TaError> {
-	use std::io::Write;
-	use std::fs::File;
-	try!(client.url(&tfile.url));
-	let mut content = Vec::new();
+fn download_test_file(
+    client: &mut Easy,
+    tfile: &TestAssetDef,
+    dir: &str,
+) -> Result<DownloadOutcome, TaError> {
+    client.url(&tfile.url)?;
+    let mut content = Vec::new();
 
-	{
-		let mut transfer = client.transfer();
-		try!(transfer.write_function(|data| {
-			content.extend_from_slice(data);
-			Ok(data.len())
-		}));
-		try!(transfer.perform());
-	}
+    {
+        let mut transfer = client.transfer();
+        transfer.write_function(|data| {
+            content.extend_from_slice(data);
+            Ok(data.len())
+        })?;
+        transfer.perform()?;
+    }
 
-	let mut hasher = Sha256::new();
-	let mut file = try!(File::create(format!("{}/{}", dir, tfile.filename)));
-	try!(file.write_all(&content));
-	hasher.input(&content);
+    let mut hasher = Sha256::new();
+    let mut file = File::create(format!("{}/{}", dir, tfile.filename))?;
+    file.write_all(&content)?;
+    hasher.update(&content);
 
-	let response_code = try!(client.response_code());
-	if response_code < 200 || response_code > 399 {
-		return Ok(DownloadOutcome::DownloadFailed(response_code));
-	}
-	return Ok(DownloadOutcome::WithHash(Sha256Hash::from_digest(&mut hasher)));
+    let response_code = client.response_code()?;
+    if response_code < 200 || response_code > 399 {
+        return Ok(DownloadOutcome::DownloadFailed(response_code));
+    }
+    return Ok(DownloadOutcome::WithHash(Sha256Hash::from_digest(
+        hasher,
+    )));
 }
 
 /// Downloads the test files into the passed directory.
-pub fn download_test_files(defs :&[TestAssetDef],
-		dir :&str, verbose :bool) -> Result<(), TaError> {
-	let mut client = Easy::new();
-	try!(client.follow_location(true));
+pub fn download_test_files(defs: &[TestAssetDef], dir: &str, verbose: bool) -> Result<(), TaError> {
+    let mut client = Easy::new();
+    client.follow_location(true)?;
 
-	use std::io::ErrorKind;
+    use std::io::ErrorKind;
 
-	let hash_list_path = format!("{}/hash_list", dir);
-	let mut hash_list = match HashList::from_file(&hash_list_path) {
-		Ok(l) => l,
-		Err(TaError::Io(ref e)) if e.kind() == ErrorKind::NotFound => HashList::new(),
-		e => { try!(e); unreachable!() },
-	};
-	try!(create_dir_all(dir));
-	for tfile in defs.iter() {
-		let tfile_hash = try!(Sha256Hash::from_hex(&tfile.hash).map_err(|_| TaError::BadHashFormat));
-		if hash_list.get_hash(&tfile.filename).map(|h| h == &tfile_hash)
-				.unwrap_or(false) {
-			// Hash match
-			if verbose {
-				println!("File {} has matching hash inside hash list, skipping download", tfile.filename);
-			}
-			continue;
-		}
-		if verbose {
-			print!("Fetching file {} ...", tfile.filename);
-		}
-		let outcome = try!(download_test_file(&mut client, tfile, dir));
-		use self::DownloadOutcome::*;
-		match &outcome {
-			&DownloadFailed(code) => return Err(TaError::DownloadFailed(code)),
-			&WithHash(ref hash) => hash_list.add_entry(&tfile.filename, hash),
-		}
-		if verbose {
-			print!("  => ");
-			match &outcome {
-				&DownloadFailed(code) => println!("Download failed with code {}", code),
-				&WithHash(ref found_hash) => {
-					if found_hash == &tfile_hash {
-						println!("Success")
-					} else {
-						println!("Hash mismatch: found {}, expected {}",
-							found_hash.to_hex(), tfile.hash)
-					}
-				 },
-			}
-		}
-	}
-	try!(hash_list.to_file(&hash_list_path));
-	Ok(())
+    let hash_list_path = format!("{}/hash_list", dir);
+    let mut hash_list = match HashList::from_file(&hash_list_path) {
+        Ok(l) => l,
+        Err(TaError::Io(ref e)) if e.kind() == ErrorKind::NotFound => HashList::new(),
+        e => {
+            e?;
+            unreachable!()
+        }
+    };
+    create_dir_all(dir)?;
+    for tfile in defs.iter() {
+        let tfile_hash = Sha256Hash::from_hex(&tfile.hash).map_err(|_| TaError::BadHashFormat)?;
+        if hash_list
+            .get_hash(&tfile.filename)
+            .map(|h| h == &tfile_hash)
+            .unwrap_or(false)
+        {
+            // Hash match
+            if verbose {
+                println!(
+                    "File {} has matching hash inside hash list, skipping download",
+                    tfile.filename
+                );
+            }
+            continue;
+        }
+        if verbose {
+            print!("Fetching file {} ...", tfile.filename);
+        }
+        let outcome = download_test_file(&mut client, tfile, dir)?;
+        use self::DownloadOutcome::*;
+        match &outcome {
+            &DownloadFailed(code) => return Err(TaError::DownloadFailed(code)),
+            &WithHash(ref hash) => hash_list.add_entry(&tfile.filename, hash),
+        }
+        if verbose {
+            print!("  => ");
+            match &outcome {
+                &DownloadFailed(code) => println!("Download failed with code {}", code),
+                &WithHash(ref found_hash) => {
+                    if found_hash == &tfile_hash {
+                        println!("Success")
+                    } else {
+                        println!(
+                            "Hash mismatch: found {}, expected {}",
+                            found_hash.to_hex(),
+                            tfile.hash
+                        )
+                    }
+                }
+            }
+        }
+    }
+    hash_list.to_file(&hash_list_path)?;
+    Ok(())
 }


### PR DESCRIPTION
I wanted to use this library for one of my libraries, but this uses an old version of sha2, updated to latest and added some rust 2021 stuff. Works just fine for my needs!

Also ran `rust fmt`.

Thanks.